### PR TITLE
HTTP server bind and shutdown fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Specify http server in proxy configuration of Postman
 - Download the binary for your platform from [Releases](https://github.com/shadowy-pycoder/go-http-proxy-to-socks/releases) page:
 
   ```shell
-  GOHPTS_RELEASE=v1.14.0; wget -v https://github.com/shadowy-pycoder/go-http-proxy-to-socks/releases/download/$GOHPTS_RELEASE/gohpts-$GOHPTS_RELEASE-linux-amd64.tar.gz -O gohpts && tar xvzf gohpts && mv -f gohpts-$GOHPTS_RELEASE-linux-amd64 gohpts && ./gohpts -h
+  GOHPTS_RELEASE=v1.14.1; wget -v https://github.com/shadowy-pycoder/go-http-proxy-to-socks/releases/download/$GOHPTS_RELEASE/gohpts-$GOHPTS_RELEASE-linux-amd64.tar.gz -O gohpts && tar xvzf gohpts && mv -f gohpts-$GOHPTS_RELEASE-linux-amd64 gohpts && ./gohpts -h
   ```
 
 - Install using `go install` command (requires Go [1.26](https://go.dev/doc/install) or later):

--- a/gohpts.go
+++ b/gohpts.go
@@ -947,14 +947,14 @@ func (p *proxyapp) Run() {
 			}
 			p.logger.Info().Msg("HTTP clients are shutting down...")
 			for _, c := range []httpClienter{p.http3LocalClient, p.http3Client, p.http3LocalClient, p.http3Client} {
-				go wg.Go(func() {
+				wg.Go(func() {
 					c.Close()
 				})
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 
 			defer cancel()
-			go wg.Go(func() {
+			wg.Go(func() {
 				p.httpServer.SetKeepAlivesEnabled(false)
 				httpServerStr := "HTTP"
 				if p.certFile != "" && p.keyFile != "" {
@@ -969,7 +969,7 @@ func (p *proxyapp) Run() {
 			})
 			if p.http3Server != nil {
 				p.logger.Info().Msg("HTTP3 Server is shutting down...")
-				go wg.Go(func() {
+				wg.Go(func() {
 					if err := p.http3Server.Shutdown(ctx); err != nil {
 						p.logger.Error().Err(err).Msg("Could not gracefully shutdown HTTP3 server")
 					} else {

--- a/gohpts.go
+++ b/gohpts.go
@@ -882,6 +882,7 @@ func (p *proxyapp) Run() {
 	if p.httpServer != nil {
 		go func() {
 			<-quit
+			signal.Ignore(os.Interrupt)
 			close(p.closeConn)
 			var wg sync.WaitGroup
 			if p.arpspoofer != nil {
@@ -1014,6 +1015,7 @@ func (p *proxyapp) Run() {
 	} else {
 		go func() {
 			<-quit
+			signal.Ignore(os.Interrupt)
 			close(p.closeConn)
 			var wg sync.WaitGroup
 			if p.arpspoofer != nil {

--- a/gohpts.go
+++ b/gohpts.go
@@ -546,7 +546,7 @@ func New(conf *Config) (*proxyapp, error) {
 	if httpEnabled {
 		// configure http server
 		hs := &http.Server{
-			Addr:           addrHTTP,
+			Addr:           p.httpServerAddr,
 			Handler:        httpHandler,
 			ReadTimeout:    readTimeout,
 			WriteTimeout:   writeTimeout,
@@ -578,7 +578,7 @@ func New(conf *Config) (*proxyapp, error) {
 			p.httpServer.Protocols.SetHTTP2(true)
 			p.httpServer.Protocols.SetUnencryptedHTTP2(true)
 			hs3 := &http3.Server{
-				Addr:           addrHTTP,
+				Addr:           p.httpServerAddr,
 				Handler:        p.replayCheck(httpHandler),
 				MaxHeaderBytes: 1 << 20,
 				TLSConfig: &tls.Config{

--- a/gohpts.go
+++ b/gohpts.go
@@ -1397,7 +1397,6 @@ func (p *proxyapp) handleTunnel(w http.ResponseWriter, r *http.Request) {
 		arrow = "->"
 	}
 	defer dstConn.Close()
-	w.WriteHeader(http.StatusOK)
 	reqChan := make(chan layers.Layer)
 	respChan := make(chan layers.Layer)
 	var wg sync.WaitGroup
@@ -1435,6 +1434,7 @@ func (p *proxyapp) handleTunnel(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer srcConn.Close()
+		srcConn.Write([]byte("HTTP/1.1 200 Connection established\r\n\r\n"))
 		srcConnRemote = srcConn.RemoteAddr().String()
 		srcConnLocal = srcConn.LocalAddr().String()
 		dstConnRemote = dstConn.RemoteAddr().String()

--- a/tproxy_linux.go
+++ b/tproxy_linux.go
@@ -457,10 +457,13 @@ ip6tables -t mangle -A GOHPTS -p tcp -d ::/128 -j RETURN
 ip6tables -t mangle -A GOHPTS -p tcp -d ::1/128 -j RETURN
 ip6tables -t mangle -A GOHPTS -p tcp -d ff00::/8 -j RETURN
 ip6tables -t mangle -A GOHPTS -p tcp -d fe80::/10 -j RETURN
+ip6tables -t mangle -A GOHPTS -p tcp -d fc00::/7 -j RETURN
 `
 			ts.p.runRuleCmd(cmdInit01)
-			if ts.p.raEnabled && ts.p.hostDNS6 != nil {
-				cmdInit02 := fmt.Sprintf(`ip6tables -t mangle -A GOHPTS -p tcp -d %s -j RETURN`, ts.p.hostDNS6.IP)
+			if prefix6, err := network.GetIPv6GlobalUnicastPrefixFromInterface(ts.p.iface); err == nil {
+				cmdInit02 := fmt.Sprintf(`
+ip6tables -t mangle -A GOHPTS -p tcp -d %s -j RETURN
+`, prefix6.Masked())
 				ts.p.runRuleCmd(cmdInit02)
 			}
 		}

--- a/tproxy_linux.go
+++ b/tproxy_linux.go
@@ -462,8 +462,8 @@ ip6tables -t mangle -A GOHPTS -p tcp -d fc00::/7 -j RETURN
 			ts.p.runRuleCmd(cmdInit01)
 			if prefix6, err := network.GetIPv6GlobalUnicastPrefixFromInterface(ts.p.iface); err == nil {
 				cmdInit02 := fmt.Sprintf(`
-ip6tables -t mangle -A GOHPTS -p tcp -d %s -j RETURN
-`, prefix6.Masked())
+ip6tables -t mangle -A GOHPTS -p tcp -s %s -d %s -j RETURN
+`, prefix6.Masked(), prefix6.Masked())
 				ts.p.runRuleCmd(cmdInit02)
 			}
 		}

--- a/tproxy_udp_linux.go
+++ b/tproxy_udp_linux.go
@@ -1218,8 +1218,8 @@ ip6tables -t mangle -A GOHPTS_UDP -p udp -d fc00::/7 -j RETURN
 			tsu.p.runRuleCmd(cmdInit01)
 			if prefix6, err := network.GetIPv6GlobalUnicastPrefixFromInterface(tsu.p.iface); err == nil {
 				cmdInit02 := fmt.Sprintf(`
-ip6tables -t mangle -A GOHPTS_UDP -p udp -d %s -j RETURN
-`, prefix6.Masked())
+ip6tables -t mangle -A GOHPTS_UDP -p udp -s %s -d %s -j RETURN
+`, prefix6.Masked(), prefix6.Masked())
 				tsu.p.runRuleCmd(cmdInit02)
 			}
 		}

--- a/tproxy_udp_linux.go
+++ b/tproxy_udp_linux.go
@@ -1216,11 +1216,10 @@ ip6tables -t mangle -A GOHPTS_UDP -p udp -d fe80::/10 -j RETURN
 ip6tables -t mangle -A GOHPTS_UDP -p udp -d fc00::/7 -j RETURN
 `
 			tsu.p.runRuleCmd(cmdInit01)
-			if tsu.p.raEnabled && tsu.p.hostDNS6 != nil {
+			if prefix6, err := network.GetIPv6GlobalUnicastPrefixFromInterface(tsu.p.iface); err == nil {
 				cmdInit02 := fmt.Sprintf(`
-ip6tables -t mangle -A GOHPTS_UDP -p udp --dport 53 -j RETURN
 ip6tables -t mangle -A GOHPTS_UDP -p udp -d %s -j RETURN
-`, tsu.p.hostDNS6.IP)
+`, prefix6.Masked())
 				tsu.p.runRuleCmd(cmdInit02)
 			}
 		}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package gohpts
 
-const Version string = "gohpts v1.14.0"
+const Version string = "gohpts v1.14.1"


### PR DESCRIPTION
## Changelog


- Fixed random waitgroup reuse after return during shutdown
- Fixed HTTP/HTTP3 server not binding to user-specified listen address by @Geker (Fixes #23)
- Removed Transfer-Encoding: chunked from CONNECT response (Fixes #24)
- Interrupts are now ignored during shutdown
- Exclude full IPv6 prefix instead of only host address (-auto flag)